### PR TITLE
compile_qemu_nyx.sh: remove call to make clean

### DIFF
--- a/compile_qemu_nyx.sh
+++ b/compile_qemu_nyx.sh
@@ -113,7 +113,6 @@ if [ -z "$LIBXDC_ROOT" -o -z "$CAPSTONE_ROOT" ]; then
 	CAPSTONE_ROOT="$PWD/capstone_v4"
 fi
 
-make clean
 compile_libraries $1
 configure_qemu $1
 compile_qemu


### PR DESCRIPTION
Remove the first `make clean` call when compiling QEMU.
This avoids wasting time when redeploying to fully recompile QEMU again, since it's not required 