### PR TITLE
Add GVT-d support

### DIFF
--- a/compile_qemu_nyx.sh
+++ b/compile_qemu_nyx.sh
@@ -30,6 +30,7 @@ error()
   echo "Available compile options: "
   echo " -  dynamic        dynamically link libxdc and capstone4"
   echo " -  static         statically link libxdc and capstone4"
+  echo " -  full_static    compile a full static QEMU build"
   echo " -  lto            enable static linking and LTO (up to 10% better performance)"
   echo " -  debug          enable debug and ASAN options"
   echo " -  debug_static   enable debug, ASAN and static linking"
@@ -40,7 +41,7 @@ error()
 compile_libraries()
 {
   case $1 in
-    "debug_static"|"static"|"lto")
+    "debug_static"|"static"|"full_static"|"lto")
       echo "[!] Compiling capstone4..."
       make -C $CAPSTONE_ROOT -j $(nproc)
 
@@ -55,7 +56,7 @@ configure_qemu()
   QEMU_CONFIGURE="./configure --target-list=x86_64-softmmu --disable-docs --disable-gtk --disable-werror --disable-capstone --disable-libssh --disable-tools"
 
   case $1 in
-    "debug_static"|"static"|"lto")
+    "debug_static"|"static"|"full_static"|"lto")
       export LIBS="-L$CAPSTONE_ROOT -L$LIBXDC_ROOT/ $LIBS"
       export QEMU_CFLAGS="-I$CAPSTONE_ROOT/include/ -I$LIBXDC_ROOT/ $QEMU_CFLAGS"
       ;;
@@ -75,6 +76,9 @@ configure_qemu()
       ;;
     "static")
       $QEMU_CONFIGURE --enable-nyx --enable-nyx-static
+      ;;
+    "full_static")
+      $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --static --disable-xkbcommon --disable-usb-redir --disable-smartcard --disable-slirp --disable-opengl --audio-drv-list= --disable-libusb --disable-rdma --disable-libiscsi
       ;;
     "lto")
       $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --enable-nyx-flto
@@ -97,7 +101,7 @@ if [ "$#" -ne 1 ] ; then
 fi
 
 case $1 in
-    "dynamic"|"debug"|"debug_static"|"static"|"lto")
+    "dynamic"|"debug"|"debug_static"|"static"|"full_static"|"lto")
       ;;
     *)
       error

--- a/compile_qemu_nyx.sh
+++ b/compile_qemu_nyx.sh
@@ -78,7 +78,7 @@ configure_qemu()
       $QEMU_CONFIGURE --enable-nyx --enable-nyx-static
       ;;
     "full_static")
-      $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --static --disable-xkbcommon --disable-usb-redir --disable-smartcard --disable-slirp --disable-opengl --audio-drv-list= --disable-libusb --disable-rdma --disable-libiscsi
+      $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --static --enable-slirp=git --disable-xkbcommon --disable-usb-redir --disable-smartcard --disable-opengl --audio-drv-list= --disable-libusb --disable-rdma --disable-libiscsi
       ;;
     "lto")
       $QEMU_CONFIGURE --enable-nyx --enable-nyx-static --enable-nyx-flto

--- a/linux-headers/linux/vfio.h
+++ b/linux-headers/linux/vfio.h
@@ -312,6 +312,7 @@ struct vfio_region_info_cap_type {
 #define VFIO_REGION_SUBTYPE_INTEL_IGD_OPREGION	(1)
 #define VFIO_REGION_SUBTYPE_INTEL_IGD_HOST_CFG	(2)
 #define VFIO_REGION_SUBTYPE_INTEL_IGD_LPC_CFG	(3)
+#define VFIO_REGION_SUBTYPE_INTEL_IGD_DSM	(4)
 
 /* 10de vendor PCI sub-types */
 /*


### PR DESCRIPTION
### Summary
This set of patches enables GVT-d for Intel integrated GPUs in QEMU. This allows for passing an integrated GPU to a VM guest. It is intended for use with a Q35 machine type.

### Dependencies
- Patched host kernel ([source](https://github.com/IntelLabs/kafl.linux/tree/gvtd/kvm-nyx-5.10.73))
- OPROM (GOP can be dumped from host machine BIOS and converted to OPROM with EDK2 BaseTools)
- IOMMU with passthrough enabled ( see command line below)
- VFIO-PCI driver (see required driver blacklist below)
- Disable framebuffer (see command line below)
- PCH device ID patched in QEMU source for host platform (see Notes below)

Add the following to your kernel command line (replace xxxx with iGPU device ID):
`intel_iommu=on iommu=pt video=efifb:off nofb vfio-pci.ids=8086:xxxx`

Create /etc/modprobe.d/blacklist-i915.conf with the following contents:
`blacklist snd_hda_intel`
`blacklist snd_hda_codec_hdmi`
`blacklist i915`

Use the following QEMU arguments (GOP_GVTD.rom is our OPROM):
`-display none -vga none -device vfio-pci,host=00:02.0,x-igd-gms=2,id=hostdev0,bus=pcie.0,addr=2,x-igd-opregion=on,romfile=GOP_GVTD.rom,driver=vfio-pci-nohotplug`

### Notes
You will need to change the PCH device ID to match the host platform in hw/isa/lpc_ich9.c.

An example for TGL:
`k->device_id = PCI_DEVICE_ID_INTEL_ICH9_8;`
to
`k->device_id = 0xA080;`
