### PR TITLE
msix: disable assertion for msix_fire_vector_notifier

### DIFF
--- a/hw/pci/msix.c
+++ b/hw/pci/msix.c
@@ -110,7 +110,8 @@ static void msix_fire_vector_notifier(PCIDevice *dev,
     } else {
         msg = msix_get_message(dev, vector);
         ret = dev->msix_vector_use_notifier(dev, vector, msg);
-        assert(ret >= 0);
+        // TODO: https://github.com/IntelLabs/kafl.qemu/issues/8
+        // assert(ret >= 0);
     }
 }
 


### PR DESCRIPTION
Should help fix #8 

This is a good enough fix so that userspace and driver fuzzing harnesses are working again on Windows, while keeping the benefit of virtio performance